### PR TITLE
add reset password with username

### DIFF
--- a/src/BrockAllen.MembershipReboot.Mvc/Areas/UserAccount/Controllers/PasswordResetController.cs
+++ b/src/BrockAllen.MembershipReboot.Mvc/Areas/UserAccount/Controllers/PasswordResetController.cs
@@ -39,7 +39,7 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
             {
                 try
                 {
-                    if (this.userAccountService.ResetPassword(model.Email))
+                    if (this.userAccountService.ResetPasswordWithEmail(model.Email))
                     {
                         return View("ResetSuccess");
                     }

--- a/src/BrockAllen.MembershipReboot.Test/Services/Accounts/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/Services/Accounts/UserAccountServiceTests.cs
@@ -1166,8 +1166,8 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
             public void NoTenantParam_PassessNullForTenant()
             {
                 var sub = new MockUserAccountService();
-                sub.Object.ResetPassword("email");
-                sub.Mock.Verify(x => x.ResetPassword(null, "email"));
+                sub.Object.ResetPasswordWithEmail("email");
+                sub.Mock.Verify(x => x.ResetPasswordWithEmail(null, "email"));
             }
             [TestMethod]
             public void MultiTenantEnabled_NullTenantParam_ReturnsFail()
@@ -1175,7 +1175,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 SecuritySettings.Instance.MultiTenant = true;
 
                 var sub = new MockUserAccountService();
-                Assert.IsFalse(sub.Object.ResetPassword(null, "email"));
+                Assert.IsFalse(sub.Object.ResetPasswordWithEmail(null, "email"));
             }
             [TestMethod]
             public void NullEmail_ReturnsFail()
@@ -1189,7 +1189,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
             {
                 var sub = new MockUserAccountService();
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns((UserAccount)null);
-                Assert.IsFalse(sub.Object.ResetPassword("email"));
+                Assert.IsFalse(sub.Object.ResetPasswordWithEmail("email"));
             }
 
             [TestMethod]
@@ -1199,7 +1199,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 var account = new MockUserAccount();
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = false;
-                Assert.IsFalse(sub.Object.ResetPassword("email"));
+                Assert.IsFalse(sub.Object.ResetPasswordWithEmail("email"));
             }
             [TestMethod]
             public void AccountNotVerified_SendAccountCreateCalled()
@@ -1209,7 +1209,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 var account = new MockUserAccount();
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = false;
-                sub.Object.ResetPassword("email");
+                sub.Object.ResetPasswordWithEmail("email");
                 sub.NotificationService.Verify(x => x.SendAccountCreate(account.Object));
             }
             [TestMethod]
@@ -1222,7 +1222,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 var account = new MockUserAccount();
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = false;
-                sub.Object.ResetPassword("email");
+                sub.Object.ResetPasswordWithEmail("email");
                 sub.NotificationService.Verify(x => x.SendAccountCreate(account.Object), Times.Never());
             }
 
@@ -1233,7 +1233,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 var account = new MockUserAccount();
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = true;
-                sub.Object.ResetPassword("email");
+                sub.Object.ResetPasswordWithEmail("email");
                 account.Verify(x => x.ResetPassword());
             }
             [TestMethod]
@@ -1244,7 +1244,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = true;
                 account.Setup(x => x.ResetPassword()).Returns(true);
-                Assert.IsTrue(sub.Object.ResetPassword("email"));
+                Assert.IsTrue(sub.Object.ResetPasswordWithEmail("email"));
             }
             [TestMethod]
             public void UserAccountResetPasswordFail_ReturnsFail()
@@ -1254,7 +1254,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = true;
                 account.Setup(x => x.ResetPassword()).Returns(false);
-                Assert.IsFalse(sub.Object.ResetPassword("email"));
+                Assert.IsFalse(sub.Object.ResetPasswordWithEmail("email"));
             }
             [TestMethod]
             public void UserAccountRepoSaveChangesCalled()
@@ -1263,7 +1263,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 var account = new MockUserAccount();
                 sub.Mock.Setup(x => x.GetByEmail(It.IsAny<string>(), It.IsAny<string>())).Returns(account.Object);
                 account.Object.IsAccountVerified = true;
-                sub.Object.ResetPassword("email");
+                sub.Object.ResetPasswordWithEmail("email");
                 sub.UserAccountRepository.Verify(x => x.SaveChanges());
             }
             [TestMethod]
@@ -1276,7 +1276,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 account.Object.IsAccountVerified = true;
                 account.Setup(x => x.ResetPassword()).Returns(true);
 
-                sub.Object.ResetPassword("email");
+                sub.Object.ResetPasswordWithEmail("email");
 
                 sub.NotificationService.Verify(x => x.SendResetPassword(account.Object));
             }
@@ -1290,7 +1290,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
                 account.Object.IsAccountVerified = true;
                 account.Setup(x => x.ResetPassword()).Returns(false);
 
-                sub.Object.ResetPassword("email");
+                sub.Object.ResetPasswordWithEmail("email");
 
                 sub.NotificationService.Verify(x => x.SendResetPassword(account.Object), Times.Never());
             }

--- a/src/BrockAllen.MembershipReboot/Services/Accounts/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/Services/Accounts/UserAccountService.cs
@@ -468,15 +468,10 @@ namespace BrockAllen.MembershipReboot
             return result;
         }
 
-        public virtual bool ResetPassword(string email)
+        // Reset password with email address
+        // Use this when EMAILISUSERNAME is enabled. Otherwise, the account may not be uniquely identified if a gievn email address is used in multiple accounts.
+        public virtual bool ResetPasswordWithEmail(string tenant, string email)
         {
-            return ResetPassword(null, email);
-        }
-
-        public virtual bool ResetPassword(string tenant, string email)
-        {
-            Tracing.Information(String.Format("[UserAccountService.ResetPassword] called: {0}, {1}", tenant, email));
-
             if (!SecuritySettings.Instance.MultiTenant)
             {
                 tenant = SecuritySettings.Instance.DefaultTenant;
@@ -486,7 +481,36 @@ namespace BrockAllen.MembershipReboot
             if (String.IsNullOrWhiteSpace(email)) return false;
 
             var account = this.GetByEmail(tenant, email);
+
+            return ResetPassword(account);
+        }
+
+        public virtual bool ResetPasswordWithEmail(string email)
+        {
+            return this.ResetPasswordWithEmail(null, email);
+        }
+
+        // Reset password with user name. Use this when EMAILISUSERNAME is disabled.
+        public virtual bool ResetPasswordWithUserName(string tenant, string username)
+        {
+            if (!SecuritySettings.Instance.MultiTenant)
+            {
+                tenant = SecuritySettings.Instance.DefaultTenant;
+            }
+
+            if (String.IsNullOrWhiteSpace(tenant)) return false;
+            if (String.IsNullOrWhiteSpace(username)) return false;
+
+            var account = this.GetByUsername(tenant, username);
+
+            return ResetPassword(account);
+        }
+
+        public virtual bool ResetPassword(UserAccount account)
+        {
             if (account == null) return false;
+
+            Tracing.Information(String.Format("[UserAccountService.ResetPassword] called: {0}, {1}", account.Username, account.Email));
 
             if (!account.IsAccountVerified)
             {


### PR DESCRIPTION
When email address is not used as user name, it is possible that an email address is registered to multiple accounts. If user tries with reset password of such an account, ResetPassword cannot determine which account to reset.

Implemented ResetPasswordWithUserName so that user's account is uniquely identified and reset when user name is not email address.
