### PR TITLE
fix email exist check not done upon account creation

### DIFF
--- a/src/BrockAllen.MembershipReboot.Test/Services/Accounts/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/Services/Accounts/UserAccountServiceTests.cs
@@ -595,7 +595,7 @@ namespace BrockAllen.MembershipReboot.Test.Services.Accounts
             public void EmailAlreadyExists_Throws()
             {
                 var sub = new MockUserAccountService();
-                sub.Mock.Setup(x => x.EmailExists(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+                sub.Mock.Setup(x => x.EmailExists(It.IsAny<string>(), It.Is<string>(e => e.CompareTo("email@test.com") == 0))).Returns(true);
                 sub.Object.CreateAccount("user", "pass", "email@test.com");
             }
 

--- a/src/BrockAllen.MembershipReboot/Services/Accounts/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/Services/Accounts/UserAccountService.cs
@@ -208,7 +208,7 @@ namespace BrockAllen.MembershipReboot
                 throw new ValidationException(msg + " already in use.");
             }
 
-            if (EmailExists(tenant, username))
+            if (EmailExists(tenant, email))
             {
                 Tracing.Verbose(String.Format("[UserAccountService.CreateAccount] Email already exists: {0}, {1}, {2}", tenant, username, email));
 


### PR DESCRIPTION
If I understand correctly, this library assumes an email address is unique
at least within a tenant.

An account creation is supposed to be blocked if the same email address
is already used in other accounts. Currently EmailExists check is
performed against "username". This does not become an issue if
EMAILISUSERNAME is enabled. However if it's disabled, there can be
multiple accounts that have the same email address.

This becomes a problem when user runs SendUsernameReminder since a given
email address can be associated with multiple usernames.
