### PR TITLE
Typo in trace message

### DIFF
--- a/src/BrockAllen.MembershipReboot/Models/UserAccount.cs
+++ b/src/BrockAllen.MembershipReboot/Models/UserAccount.cs
@@ -383,7 +383,7 @@ namespace BrockAllen.MembershipReboot
 
         protected internal virtual void CloseAccount()
         {
-            Tracing.Verbose(String.Format("[UserAccount.CloseAccount] called on: {0}, {0}", Tenant, Username));
+            Tracing.Verbose(String.Format("[UserAccount.CloseAccount] called on: {0}, {1}", Tenant, Username));
 
             this.ClearVerificationKey();
             IsLoginAllowed = false;


### PR DESCRIPTION
Hi, I was looking around the source and found a typo in one of the trace messages in UserAccount.cs. Changed from

``` csharp
Tracing.Verbose(String.Format("[UserAccount.CloseAccount] called on: {0}, {0}", Tenant, Username));
```

to

``` csharp
Tracing.Verbose(String.Format("[UserAccount.CloseAccount] called on: {0}, {1}", Tenant, Username));
```
