### PR TITLE
Make SqlServerConfig and SqlCeConfig public

### DIFF
--- a/src/BrockAllen.MembershipReboot/Migrations.SqlCe/SqlCeConfig.cs
+++ b/src/BrockAllen.MembershipReboot/Migrations.SqlCe/SqlCeConfig.cs
@@ -2,7 +2,7 @@ namespace BrockAllen.MembershipReboot.Migrations.SqlCe
 {
     using System.Data.Entity.Migrations;
 
-    internal sealed class SqlCeConfig : DbMigrationsConfiguration<BrockAllen.MembershipReboot.EFMembershipRebootDatabase>
+    public class SqlCeConfig : DbMigrationsConfiguration<BrockAllen.MembershipReboot.EFMembershipRebootDatabase>
     {
         public SqlCeConfig()
         {

--- a/src/BrockAllen.MembershipReboot/Migrations.SqlServer/SqlServerConfig.cs
+++ b/src/BrockAllen.MembershipReboot/Migrations.SqlServer/SqlServerConfig.cs
@@ -2,7 +2,7 @@ namespace BrockAllen.MembershipReboot.Migrations.SqlServer
 {
     using System.Data.Entity.Migrations;
 
-    internal sealed class SqlServerConfig : DbMigrationsConfiguration<BrockAllen.MembershipReboot.EFMembershipRebootDatabase>
+    public class SqlServerConfig : DbMigrationsConfiguration<BrockAllen.MembershipReboot.EFMembershipRebootDatabase>
     {
         public SqlServerConfig()
         {


### PR DESCRIPTION
In order to run Code First Migration using DbMigrator, DbMigrationsConfiguration needs to be public.

This is needed for host project to be able to run Code First Migration with good controls.
