### PR TITLE
fix(Owin): owin app info compilation error

### DIFF
--- a/src/BrockAllen.MembershipReboot.Owin/OwinApplicationInformation.cs
+++ b/src/BrockAllen.MembershipReboot.Owin/OwinApplicationInformation.cs
@@ -26,8 +26,8 @@ namespace BrockAllen.MembershipReboot.Owin
             this.ApplicationName = appName;
             this.EmailSignature = emailSig;
             this.RelativeLoginUrl = relativeLoginUrl;
-            this.RelativeVerifyAccountUrl = relativeVerifyAccountUrl;
-            this.RelativeCancelNewAccountUrl = relativeCancelNewAccountUrl;
+            this.VerifyAccountUrl = relativeVerifyAccountUrl;
+            this.CancelVerificationUrl = relativeCancelNewAccountUrl;
             this.RelativeConfirmPasswordResetUrl = relativeConfirmPasswordResetUrl;
             this.RelativeConfirmChangeEmailUrl = relativeConfirmChangeEmailUrl;
         }

--- a/src/BrockAllen.MembershipReboot/Configuration/ApplicationInformation.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/ApplicationInformation.cs
@@ -14,6 +14,7 @@ namespace BrockAllen.MembershipReboot
 
         public virtual string ConfirmPasswordResetUrl { get; set; }
         public virtual string ConfirmChangeEmailUrl { get; set; }
+        public virtual string VerifyAccountUrl { get; set; }
         public virtual string CancelVerificationUrl { get; set; }
     }
 }


### PR DESCRIPTION
Non-existent property. Wasn't too sure why they were removed so added them back to get it compiling.
