### PR TITLE
Mongo Sample Yellow Screen Fix. 

### DIFF
--- a/samples/NoSql/BrockAllen.MembershipReboot.MongoDb/MongoDatabase.cs
+++ b/samples/NoSql/BrockAllen.MembershipReboot.MongoDb/MongoDatabase.cs
@@ -15,11 +15,13 @@ namespace BrockAllen.MembershipReboot.MongoDb
                 cm.MapIdProperty(c => c.ID);
             });
 
-            BsonClassMap.RegisterClassMap<HierarchicalUserAccount>(cm =>
+            BsonClassMap.RegisterClassMap<UserAccount>(cm =>
             {
                 cm.AutoMap();
                 cm.MapIdProperty(c => c.ID);
             });
+
+            BsonClassMap.RegisterClassMap<HierarchicalUserAccount>(cm => cm.AutoMap());
         }
 
         private readonly string _connectionStringName;


### PR DESCRIPTION
Mongo requires that you register parent classes before you register their derived offspring. I just added a couple lines to that effect.
