### PR TITLE
feat(AuthenticationService): Auto-generate a password for accounts creat..

### DIFF
--- a/samples/CustomizationsSample/CustomizationsSample/App_Start/MembershipRebootConfiguration.cs
+++ b/samples/CustomizationsSample/CustomizationsSample/App_Start/MembershipRebootConfiguration.cs
@@ -17,6 +17,10 @@ namespace BrockAllen.MembershipReboot.Mvc.App_Start
             config.RegisterPasswordValidator(new PasswordValidator());
             config.ConfigurePasswordComplexity(5, 3);
 
+            // obviously for production you do NOT want to use a static password
+            // a resonable alternate for production would be to use MembershipProvider (uncomment code below)
+//            config.PasswordGenerator = () => Membership.GeneratePassword(15, 5);
+
             config.AddCommandHandler(new CustomClaimsMapper());
 
             var delivery = new SmtpMessageDelivery();

--- a/src/BrockAllen.MembershipReboot.WebHost/SamAuthenticationService.cs
+++ b/src/BrockAllen.MembershipReboot.WebHost/SamAuthenticationService.cs
@@ -13,9 +13,15 @@ namespace BrockAllen.MembershipReboot.WebHost
     public class SamAuthenticationService : AuthenticationService
     {
         public SamAuthenticationService(UserAccountService userAccountService)
-            : base(userAccountService)
+            : base(userAccountService, FederatedAuthentication.FederationConfiguration.IdentityConfiguration.ClaimsAuthenticationManager)
         {
         }
+
+        public SamAuthenticationService(UserAccountService<UserAccount> userService, MembershipRebootConfiguration<UserAccount> configuration)
+            : base(userService, FederatedAuthentication.FederationConfiguration.IdentityConfiguration.ClaimsAuthenticationManager, configuration)
+        {
+        }
+
 
         protected override void IssueToken(ClaimsPrincipal principal, TimeSpan? tokenLifetime = null, bool? persistentCookie = null)
         {
@@ -77,6 +83,11 @@ namespace BrockAllen.MembershipReboot.WebHost
     {
         public SamAuthenticationService(UserAccountService<T> userService)
             : base(userService, FederatedAuthentication.FederationConfiguration.IdentityConfiguration.ClaimsAuthenticationManager)
+        {
+        }
+
+        public SamAuthenticationService(UserAccountService<T> userService, MembershipRebootConfiguration<T> configuration)
+            : base(userService, FederatedAuthentication.FederationConfiguration.IdentityConfiguration.ClaimsAuthenticationManager, configuration)
         {
         }
 

--- a/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
+++ b/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
@@ -15,6 +15,7 @@ namespace BrockAllen.MembershipReboot
     public abstract class AuthenticationService<TAccount>
         where TAccount : UserAccount
     {
+        public MembershipRebootConfiguration<TAccount> Configuration { get; set; }
         public UserAccountService<TAccount> UserAccountService { get; set; }
         public ClaimsAuthenticationManager ClaimsAuthenticationManager { get; set; }
 
@@ -24,7 +25,13 @@ namespace BrockAllen.MembershipReboot
         }
 
         public AuthenticationService(UserAccountService<TAccount> userService, ClaimsAuthenticationManager claimsAuthenticationManager)
+            : this(userService, claimsAuthenticationManager, new MembershipRebootConfiguration<TAccount>())
         {
+        }
+
+        public AuthenticationService(UserAccountService<TAccount> userService, ClaimsAuthenticationManager claimsAuthenticationManager, MembershipRebootConfiguration<TAccount> configuration)
+        {
+            this.Configuration = configuration;
             this.UserAccountService = userService;
             this.ClaimsAuthenticationManager = claimsAuthenticationManager;
         }
@@ -221,7 +228,7 @@ namespace BrockAllen.MembershipReboot
                     // this is slightly dangerous if we don't do email account verification, so if email account
                     // verification is disabled then we need to be very confident that the external provider has
                     // provided us with a verified email
-                    account = this.UserAccountService.CreateAccount(tenant, name, null, email);
+                    account = this.UserAccountService.CreateAccount(tenant, name, this.Configuration.PasswordGenerator(), email);
                 }
             }
 
@@ -264,6 +271,11 @@ namespace BrockAllen.MembershipReboot
 
         public AuthenticationService(UserAccountService userService, ClaimsAuthenticationManager claimsAuthenticationManager)
             : base(userService, claimsAuthenticationManager)
+        {
+        }
+
+        protected AuthenticationService(UserAccountService<UserAccount> userService, ClaimsAuthenticationManager claimsAuthenticationManager, MembershipRebootConfiguration<UserAccount> configuration) 
+            : base(userService, claimsAuthenticationManager, configuration)
         {
         }
     }

--- a/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
@@ -32,6 +32,8 @@ namespace BrockAllen.MembershipReboot
             this.PasswordResetFrequency = securitySettings.PasswordResetFrequency;
 
             this.Crypto = new DefaultCrypto();
+            // todo: consider plugin in a default random strong password algorithm then consider renaming property to RandomPasswordGenerator
+            this.PasswordGenerator = () => null;
         }
 
         public bool MultiTenant { get; set; }
@@ -89,6 +91,8 @@ namespace BrockAllen.MembershipReboot
         }
         
         public ICrypto Crypto { get; set; }
+
+        public Func<string> PasswordGenerator { get; set; }
     }
     
     public class MembershipRebootConfiguration : MembershipRebootConfiguration<UserAccount>


### PR DESCRIPTION
...ed by SignInWithLinkedAccount

Allow a PasswordGenerator to be defined as MembershipRebootConfiguration
Use the configured generator to auto-gen a password when AuthenticationService.SignInWithLinkedAccount creates a new account
