### PR TITLE
Feat(AuthenticationService): SignInWithLinkedAccount maps claims to acco...

### DIFF
--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountCommands.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountCommands.cs
@@ -38,4 +38,11 @@ namespace BrockAllen.MembershipReboot
         public TAccount Account { get; set; }
         public IEnumerable<Claim> MappedClaims { get; set; }
     }
+
+    public class MapClaimsToAccount<TAccount> : ICommand
+        where TAccount : UserAccount
+    {
+        public TAccount Account { get; set; }
+        public IEnumerable<Claim> Claims { get; set; }
+    }
 }

--- a/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
+++ b/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
@@ -222,6 +222,11 @@ namespace BrockAllen.MembershipReboot
                     // verification is disabled then we need to be very confident that the external provider has
                     // provided us with a verified email
                     account = this.UserAccountService.CreateAccount(tenant, name, null, email);
+
+                    // update account with external claims
+                    var cmd = new MapClaimsToAccount<TAccount> { Account = account, Claims = claims };
+                    this.UserAccountService.ExecuteCommand(cmd);
+                    this.UserAccountService.Update(account);
                 }
             }
 


### PR DESCRIPTION
...unt properties

There is now the facility to define a mapping of claims to account properties. This mapping is executed when SignInWithLinkedAccount creates an account to populate account properties from the external claims supplied

This is the inverse of MapClaimsFromAccount command handler
