### PR TITLE
Add generator for string.Equals(string, StringComparison).

### DIFF
--- a/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/BrockAllen.MembershipReboot.Nh.csproj
+++ b/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/BrockAllen.MembershipReboot.Nh.csproj
@@ -52,6 +52,9 @@
     <Compile Include="Account\NhUserAccount.cs" />
     <Compile Include="Account\NhUserCertificate.cs" />
     <Compile Include="Account\NhUserClaim.cs" />
+    <Compile Include="Extensions\ConfigurationExtensions.cs" />
+    <Compile Include="Extensions\MembershipRebootLinqToHqlGeneratorsRegistry.cs" />
+    <Compile Include="Extensions\StringComparisonEqualsGenerator.cs" />
     <Compile Include="Groups\NhGroup.cs" />
     <Compile Include="Groups\NhGroupChild.cs" />
     <Compile Include="Mappings\Mappings.cs" />

--- a/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Extensions/ConfigurationExtensions.cs
+++ b/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,38 @@
+﻿namespace BrockAllen.MembershipReboot.Nh.Extensions
+{
+    using System;
+    using System.Reflection;
+
+    using BrockAllen.MembershipReboot.Nh.Mappings;
+
+    using NHibernate.Cfg;
+    using NHibernate.Dialect;
+    using NHibernate.Mapping.ByCode;
+
+    public static class ConfigurationExtensions
+    {
+        /// <summary>
+        /// Call this method to add class mappings and any MembershipReboot configuration.
+        /// This method must be called after a call to Configure().
+        /// </summary>
+        /// <param name="configuration"></param>
+        public static void ConfigureMembershipReboot(this Configuration configuration)
+        {
+            // Hack to check if Configure() has been called. Should find a better way.
+            string dialectName;
+            if (!configuration.Properties.TryGetValue("dialect", out dialectName))
+            {
+                throw new InvalidOperationException("Could not find the dialect in the configuration. Have you called the Configuration.Configure() method?");
+            }
+
+            // Register the generators registry class.
+            configuration.LinqToHqlGeneratorsRegistry<MembershipRebootLinqToHqlGeneratorsRegistry>();
+
+            // Add mappings for the classes.
+            var mapper = new ModelMapper();
+            mapper.AddMappings(Assembly.GetAssembly(typeof(UserAccountMapping)).GetExportedTypes());
+            var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+            configuration.AddMapping(mapping);
+        }
+    }
+}

--- a/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Extensions/MembershipRebootLinqToHqlGeneratorsRegistry.cs
+++ b/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Extensions/MembershipRebootLinqToHqlGeneratorsRegistry.cs
@@ -1,0 +1,18 @@
+﻿namespace BrockAllen.MembershipReboot.Nh.Extensions
+{
+    using System;
+
+    using NHibernate.Linq;
+    using NHibernate.Linq.Functions;
+
+    public class MembershipRebootLinqToHqlGeneratorsRegistry : DefaultLinqToHqlGeneratorsRegistry
+    {
+        public MembershipRebootLinqToHqlGeneratorsRegistry() : base()
+        {
+            // Register the string.Equals(string, StringComparison) generator.
+            this.RegisterGenerator(
+                ReflectionHelper.GetMethodDefinition<string>(x => x.Equals(null, StringComparison.CurrentCulture)),
+                new StringComparisonEqualsGenerator());
+        }
+    }
+}

--- a/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Extensions/StringComparisonEqualsGenerator.cs
+++ b/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Extensions/StringComparisonEqualsGenerator.cs
@@ -1,0 +1,52 @@
+﻿namespace BrockAllen.MembershipReboot.Nh.Extensions
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    using NHibernate.Hql.Ast;
+    using NHibernate.Linq;
+    using NHibernate.Linq.Functions;
+    using NHibernate.Linq.Visitors;
+
+    public class StringComparisonEqualsGenerator : BaseHqlGeneratorForMethod
+    {
+        public StringComparisonEqualsGenerator()
+        {
+            SupportedMethods = new[]
+                                   {
+                                       ReflectionHelper.GetMethodDefinition<string>(
+                                           x => x.Equals(null, StringComparison.CurrentCulture))
+                                   };
+        }
+
+        public override HqlTreeNode BuildHql(
+            MethodInfo method,
+            Expression targetObject,
+            ReadOnlyCollection<Expression> arguments,
+            HqlTreeBuilder treeBuilder,
+            IHqlExpressionVisitor visitor)
+        {
+            // Get the StringComparison argument.
+            var comparison = (StringComparison)(arguments[1].As<ConstantExpression>().Value);
+
+            if (comparison == StringComparison.CurrentCultureIgnoreCase
+                || comparison == StringComparison.InvariantCultureIgnoreCase
+                || comparison == StringComparison.OrdinalIgnoreCase)
+            {
+                // If the comparison calls for us to ignore the case, use SQL LOWER()
+                return
+                    treeBuilder.Equality(
+                        treeBuilder.MethodCall("lower", new[] { visitor.Visit(targetObject).AsExpression() }),
+                        treeBuilder.MethodCall("lower", new[] { visitor.Visit(arguments[0]).AsExpression() }));
+            }
+
+            // Otherwise use the database's default string comparison mechanism.
+            return treeBuilder.Equality(
+                visitor.Visit(targetObject).AsExpression(),
+                visitor.Visit(arguments[0]).AsExpression());
+        }
+    }
+}

--- a/samples/NhibernateSample/NhibernateSample/App_Start/NhibernateConfig.cs
+++ b/samples/NhibernateSample/NhibernateSample/App_Start/NhibernateConfig.cs
@@ -1,13 +1,9 @@
 ﻿namespace NhibernateSample
 {
-    using System.Reflection;
-
-    using BrockAllen.MembershipReboot.Nh.Mappings;
+    using BrockAllen.MembershipReboot.Nh.Extensions;
 
     using NHibernate;
     using NHibernate.Cfg;
-    using NHibernate.Cfg.MappingSchema;
-    using NHibernate.Mapping.ByCode;
 
     public class NhibernateConfig
     {
@@ -22,18 +18,8 @@
         {
             var config = new Configuration();
             config.Configure();
-            config.AddMapping(GetMappings());
+            config.ConfigureMembershipReboot();
             return config;
-        }
-
-        private static HbmMapping GetMappings()
-        {
-            var mapper = new ModelMapper();
-
-            mapper.AddMappings(Assembly.GetAssembly(typeof(UserAccountMapping)).GetExportedTypes());
-            var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
-
-            return mapping;
         }
     }
 }


### PR DESCRIPTION
This commit adds support for the string.Equals(string, StringComparison) method in NHibernate which fixes the string comparison issue in the sample. It also ensures that all database engines use the LOWER() function for case insensitive comparisons (if their dialects support it). I've tested it with SQLite.
