### PR TITLE
Fix invalid view names for redirect

### DIFF
--- a/samples/NoSql/SingleTenantWebApp/Areas/UserAccount/Controllers/PasswordResetController.cs
+++ b/samples/NoSql/SingleTenantWebApp/Areas/UserAccount/Controllers/PasswordResetController.cs
@@ -60,10 +60,10 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
                     ModelState.AddModelError("", ex.Message);
                 }
             }
-            return View("Index"); 
+            return View("Index");
         }
 
-       
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public ActionResult ResetWithQuestions(PasswordResetWithSecretInputModel model)
@@ -72,8 +72,8 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
             {
                 try
                 {
-                    var answers = 
-                        model.Questions.Select(x=>new PasswordResetQuestionAnswer{QuestionID = x.QuestionID, Answer = x.Answer} );
+                    var answers =
+                        model.Questions.Select(x => new PasswordResetQuestionAnswer { QuestionID = x.QuestionID, Answer = x.Answer });
                     this.userAccountService.ResetPasswordFromSecretQuestionAndAnswer(model.UnprotectedAccountID.Value, answers.ToArray());
                     return View("ResetSuccess");
                 }
@@ -101,7 +101,7 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
                 }
             }
 
-            return RedirectToAction("ResetWithSecret");
+            return RedirectToAction("Index");
         }
 
         public ActionResult Confirm(string id)

--- a/samples/SingleTenant/SingleTenantWebApp/Areas/UserAccount/Controllers/PasswordResetController.cs
+++ b/samples/SingleTenant/SingleTenantWebApp/Areas/UserAccount/Controllers/PasswordResetController.cs
@@ -59,10 +59,10 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
                     ModelState.AddModelError("", ex.Message);
                 }
             }
-            return View("Index"); 
+            return View("Index");
         }
 
-       
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public ActionResult ResetWithQuestions(PasswordResetWithSecretInputModel model)
@@ -71,8 +71,8 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
             {
                 try
                 {
-                    var answers = 
-                        model.Questions.Select(x=>new PasswordResetQuestionAnswer{QuestionID = x.QuestionID, Answer = x.Answer} );
+                    var answers =
+                        model.Questions.Select(x => new PasswordResetQuestionAnswer { QuestionID = x.QuestionID, Answer = x.Answer });
                     this.userAccountService.ResetPasswordFromSecretQuestionAndAnswer(model.UnprotectedAccountID.Value, answers.ToArray());
                     return View("ResetSuccess");
                 }
@@ -100,7 +100,7 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
                 }
             }
 
-            return RedirectToAction("ResetWithSecret");
+            return RedirectToAction("Index");
         }
 
         public ActionResult Confirm(string id)

--- a/samples/SingleTenantOwinSystemWeb/SingleTenantOwinSystemWeb/Areas/UserAccount/Controllers/PasswordResetController.cs
+++ b/samples/SingleTenantOwinSystemWeb/SingleTenantOwinSystemWeb/Areas/UserAccount/Controllers/PasswordResetController.cs
@@ -59,10 +59,10 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
                     ModelState.AddModelError("", ex.Message);
                 }
             }
-            return View("Index"); 
+            return View("Index");
         }
 
-       
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public ActionResult ResetWithQuestions(PasswordResetWithSecretInputModel model)
@@ -71,8 +71,8 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
             {
                 try
                 {
-                    var answers = 
-                        model.Questions.Select(x=>new PasswordResetQuestionAnswer{QuestionID = x.QuestionID, Answer = x.Answer} );
+                    var answers =
+                        model.Questions.Select(x => new PasswordResetQuestionAnswer { QuestionID = x.QuestionID, Answer = x.Answer });
                     this.userAccountService.ResetPasswordFromSecretQuestionAndAnswer(model.UnprotectedAccountID.Value, answers.ToArray());
                     return View("ResetSuccess");
                 }
@@ -100,7 +100,7 @@ namespace BrockAllen.MembershipReboot.Mvc.Areas.UserAccount.Controllers
                 }
             }
 
-            return RedirectToAction("ResetWithSecret");
+            return RedirectToAction("Index");
         }
 
         public ActionResult Confirm(string id)


### PR DESCRIPTION
I couldn't see any view named "ResetWithSecret" anywhere in these samples, so I'm guessing it should redirect to the "Index" view instead.
