### PR TITLE
Fix(MembershipReboot.Ef): Repository should not always call DbContext.Di...

### DIFF
--- a/src/BrockAllen.MembershipReboot.Ef/DbContextGroupRepository.cs
+++ b/src/BrockAllen.MembershipReboot.Ef/DbContextGroupRepository.cs
@@ -14,11 +14,13 @@ namespace BrockAllen.MembershipReboot.Ef
         where TGroup : RelationalGroup
     {
         protected DbContext db;
+        bool isContextOwner;
         DbSet<TGroup> items;
         
         public DbContextGroupRepository()
             : this(new Ctx())
         {
+            isContextOwner = true;
         }
         public DbContextGroupRepository(Ctx ctx)
         {
@@ -36,11 +38,12 @@ namespace BrockAllen.MembershipReboot.Ef
 
         public void Dispose()
         {
-            if (db.TryDispose())
+            if (isContextOwner)
             {
-                db = null;
-                items = null;
+                db.TryDispose();
             }
+            db = null;
+            items = null;
         }
 
         protected override IQueryable<TGroup> Queryable

--- a/src/BrockAllen.MembershipReboot.Ef/DbContextUserAccountRepository.cs
+++ b/src/BrockAllen.MembershipReboot.Ef/DbContextUserAccountRepository.cs
@@ -15,11 +15,13 @@ namespace BrockAllen.MembershipReboot.Ef
         where TAccount : RelationalUserAccount
     {
         protected DbContext db;
+        bool isContextOwner;
         DbSet<TAccount> items;
 
         public DbContextUserAccountRepository()
             : this(new Ctx())
         {
+            isContextOwner = true;
         }
 
         public DbContextUserAccountRepository(Ctx ctx)
@@ -38,11 +40,12 @@ namespace BrockAllen.MembershipReboot.Ef
 
         public void Dispose()
         {
-            if (db.TryDispose())
+            if (isContextOwner)
             {
-                db = null;
-                items = null;
+                db.TryDispose();
             }
+            db = null;
+            items = null;
         }
 
         protected override IQueryable<TAccount> Queryable


### PR DESCRIPTION
...spose

A Repository should only dispose of a DbContext that it created / owns
