### PR TITLE
Added missing ToList() in RemoveChildGroupsFromOtherGroups

### DIFF
--- a/src/BrockAllen.MembershipReboot/Groups/GroupService.cs
+++ b/src/BrockAllen.MembershipReboot/Groups/GroupService.cs
@@ -89,7 +89,7 @@ namespace BrockAllen.MembershipReboot
 
         private void RemoveChildGroupFromOtherGroups(Guid childGroupID)
         {
-            var groups = this.groupRepository.GetByChildID(childGroupID);
+            var groups = this.groupRepository.GetByChildID(childGroupID).ToList();
             foreach (var group in groups)
             {
                 RemoveChildGroup(group, childGroupID);


### PR DESCRIPTION
The `RemoveChildGroupFromOtherGroups` method in `GroupService` doesn't have a `ToList()` on the end of `groupRepository.GetByChildID(childGroupID)` which causes "There is already an open DataReader associated with this Command" errors when deleting groups.

The error is caused because the query that retrieves the child IDs is not complete when the call to Update() is made.