### PR TITLE
Update Mappings

### DIFF
--- a/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Mappings/Mappings.cs
+++ b/samples/NhibernateSample/BrockAllen.MembershipReboot.Nh/Mappings/Mappings.cs
@@ -41,7 +41,7 @@
                 spm =>
                 {
                     spm.Inverse(true);
-                    spm.Cascade(Cascade.All);
+                    spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                     spm.Key(
                         km =>
                         {
@@ -289,7 +289,7 @@
                 spm =>
                     {
                         spm.Inverse(true);
-                        spm.Cascade(Cascade.All);
+                        spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                         spm.Key(
                             km =>
                                 {
@@ -303,7 +303,7 @@
                 spm =>
                 {
                     spm.Inverse(true);
-                    spm.Cascade(Cascade.All);
+                    spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                     spm.Key(
                         km =>
                         {
@@ -317,7 +317,7 @@
                 spm =>
                 {
                     spm.Inverse(true);
-                    spm.Cascade(Cascade.All);
+                    spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                     spm.Key(
                         km =>
                         {
@@ -331,7 +331,7 @@
                 spm =>
                 {
                     spm.Inverse(true);
-                    spm.Cascade(Cascade.All);
+                    spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                     spm.Key(
                         km =>
                         {
@@ -345,7 +345,7 @@
                 spm =>
                 {
                     spm.Inverse(true);
-                    spm.Cascade(Cascade.All);
+                    spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                     spm.Key(
                         km =>
                         {
@@ -359,7 +359,7 @@
                 spm =>
                 {
                     spm.Inverse(true);
-                    spm.Cascade(Cascade.All);
+                    spm.Cascade(Cascade.All | Cascade.DeleteOrphans);
                     spm.Key(
                         km =>
                         {


### PR DESCRIPTION
Update Child Collections Mapping, set the cascade style to both all and delete-orphan which enables deletion of items that has been removed from the collection when saving/updating parent item. With only cascade all the following user account service method will not work (Child collection item will not be deleted):

- RemoveCertificate
- RemoveClaim
- RemoveClaims
- RemoveLinkedAccount
- RemoveLinkedAccountClaims
- RemovePasswordResetSecret
- RemoveTwoFactorAuthTokens