### PR TITLE
fix(AuthenticationService{T}): SignInWithLinkedAccount should include special characters in username

### DIFF
--- a/src/BrockAllen.MembershipReboot.Test/Authentication/SignInWithLinkedAccountTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/Authentication/SignInWithLinkedAccountTests.cs
@@ -48,21 +48,47 @@ namespace BrockAllen.MembershipReboot.Test.Authentication
             subject.SignInWithLinkedAccount("google", "123", new[]
             {
                 new Claim(ClaimTypes.Email, "test@gmail.com"),
-                new Claim(ClaimTypes.Name, "Christian"),
+                new Claim(ClaimTypes.Name, "Christian")
             });
             var addedAccount = repository.UserAccounts[0];
             Assert.AreEqual("Christian", addedAccount.Username);
         }
 
         [TestMethod]
-        public void Failback_To_Guessing_Username_From_Email_For_New_UserAccount()
+        public void Use_NameClaim_Stripped_Of_Invalid_Chars_For_New_UserAccount()
         {
             subject.SignInWithLinkedAccount("google", "123", new[]
             {
-                new Claim(ClaimTypes.Email, "test@gmail.com")
+                new Claim(ClaimTypes.Email, "test@gmail.com"),
+                new Claim(ClaimTypes.Name, " ~ Christian Crowhurst @ ")
             });
             var addedAccount = repository.UserAccounts[0];
-            Assert.AreEqual("test", addedAccount.Username);
+            Assert.AreEqual("Christian Crowhurst", addedAccount.Username);
+        }
+
+        [TestMethod]
+        public void Guessed_Username_Should_Strip_Invalid_Chars()
+        {
+            subject.SignInWithLinkedAccount("google", "123", new[]
+            {
+                new Claim(ClaimTypes.Email, "test@gmail.com"),
+                new Claim(ClaimTypes.Name, " ~ Christian Crowhurst @ ")
+            });
+            var addedAccount = repository.UserAccounts[0];
+            Assert.AreEqual("Christian Crowhurst", addedAccount.Username);
+        }
+
+        [TestMethod]
+        [Description("For list of allowed special chars see UserAccountValidation<TAccount>")]
+        public void Guessed_Username_Should_Allow_Special_Chars()
+        {
+            subject.SignInWithLinkedAccount("google", "123", new[]
+            {
+                new Claim(ClaimTypes.Email, "test@gmail.com"),
+                new Claim(ClaimTypes.Name, @" ~ Christian.Forrest-Smith_OK @ ")
+            });
+            var addedAccount = repository.UserAccounts[0];
+            Assert.AreEqual("Christian.Forrest-Smith_OK", addedAccount.Username);
         }
     }
 }

--- a/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
+++ b/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
@@ -211,14 +211,14 @@ namespace BrockAllen.MembershipReboot
                     // guess at a username to use
                     var name = claims.GetValue(ClaimTypes.Name);
                     // remove whitespace
-                    if (name != null) name = new String(name.Where(x => Char.IsLetterOrDigit(x)).ToArray());
+                    if (name != null) name = ParseValidUsername(name);
                     
                     // check to see if username already exists
                     if (String.IsNullOrWhiteSpace(name) || this.UserAccountService.UsernameExists(tenant, name))
                     {
                         // try use email for name then
                         name = email.Substring(0, email.IndexOf('@'));
-                        name = new String(name.Where(x=>Char.IsLetterOrDigit(x)).ToArray());
+                        name = ParseValidUsername(name);
 
                         if (this.UserAccountService.UsernameExists(tenant, name))
                         {
@@ -262,6 +262,12 @@ namespace BrockAllen.MembershipReboot
             {
                 Tracing.Error("[AuthenticationService.SignInWithLinkedAccount] user account not verified, not allowed to login: {0}", account.ID);
             }
+        }
+
+        private static string ParseValidUsername(string name)
+        {
+            IEnumerable<char> validChars = name.Where(UserAccountValidation<TAccount>.IsValidUsernameChar);
+            return new String(validChars.ToArray()).Trim();
         }
 
         public virtual void SignOut()


### PR DESCRIPTION
Hi Brock,

I never did get around to testing out the issue raised here: #284

Well I had a problem in production (should have known!).

This pull request is required to support a username guessed by SignInWithLinkedAccount that will include special characters.

I do think it breaks backwards compatibility hence I don't think I should commit without you giving the go ahead.