### PR TITLE
clear FailedLoginCount when calling ChangePasswordFromResetKey

### DIFF
--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -1392,6 +1392,9 @@ namespace BrockAllen.MembershipReboot
 
             ClearVerificationKey(account);
             SetPassword(account, newPassword);
+
+            account.FailedLoginCount = 0;
+
             Update(account);
 
             return true;


### PR DESCRIPTION
Clearing FailedLoginCount when calling ChangePasswordFromResetKey, otherwise the user needs to wait until their lockout period expires.