### PR TITLE
Changed the auto property to a backing field for the ClaimCollection …

### DIFF
--- a/src/BrockAllen.MembershipReboot/Account/Relational/RelationalUserAccount.cs
+++ b/src/BrockAllen.MembershipReboot/Account/Relational/RelationalUserAccount.cs
@@ -15,9 +15,16 @@ namespace BrockAllen.MembershipReboot.Relational
         where TTwoFactorAuthToken : RelationalTwoFactorAuthToken<TKey>, new()
         where TUserCertificate : RelationalUserCertificate<TKey>, new()
     {
+        private ICollection<TUserClaim> claimCollection; 
+        
         public virtual TKey Key { get; set; }
 
-        public virtual ICollection<TUserClaim> ClaimCollection { get; set; }
+        public virtual ICollection<TUserClaim> ClaimCollection
+        {
+            get { return claimCollection ?? (claimCollection = new HashSet<TUserClaim>()); }
+            set { claimCollection = value; }
+        }
+        
         public override IEnumerable<UserClaim> Claims
         {
             get { return ClaimCollection; }


### PR DESCRIPTION
…property on the RelationalUserAccount, so that we can do a null check in the getter.

This property is a mapped EF property which is only being set by EF when retrieved from the database. When the RelationalUserAccount is created by the idmservice and the DbContext is not renewed, EF won't update the Entity resulting in a null exception when doing more operations on the account (like adding claims).