### PR TITLE
Allow to create account with initial claims

### DIFF
--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -675,14 +675,14 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
         [TestMethod]
         public void CreateAccount_CanPassCreatedDate_UsesCreatedDate()
         {
-            var created = DateTime.Now;
+            var created = DateTime.UtcNow;
             var acct = subject.CreateAccount("user", "pass", "test@test.com", null, created);
             Assert.AreEqual(created, acct.Created);
         }
         [TestMethod]
         public void CreateAccount_FutureCreatedDate_Throws()
         {
-            var created = DateTime.Now.AddDays(1);
+            var created = DateTime.UtcNow.AddDays(1);
             try
             {
                 var acct = subject.CreateAccount("user", "pass", "test@test.com", null, created);

--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -539,6 +539,22 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
             Assert.AreSame(acct, result);
         }
 
+        [TestMethod]
+        public void CreateAccount_AllowClaimsToBePassedIn()
+        {
+            MyUserAccount acct = new MyUserAccount();
+            List<Claim> claims = new List<Claim> {new Claim("foo", "bar")};
+            var result = subject.CreateAccount("tenant", "user", "pass", "user@email.com", null, null, acct, claims);
+            Assert.AreSame(acct, result);
+
+            var comparer = new UserClaimComparer();
+            var userClaims = claims.Select(c => new UserClaim(c.Type, c.Value));
+            CollectionAssert.AreEqual(
+                userClaims.OrderBy(c => c, comparer).ToList(),
+                result.Claims.OrderBy(c => c, comparer).ToList(),
+                comparer);
+        }
+
 
         [TestMethod]
         public void CreateMethod_UsernameStartsOrEndNonLetterOrDigit_FailsValidation()

--- a/src/BrockAllen.MembershipReboot/Account/UserClaim.cs
+++ b/src/BrockAllen.MembershipReboot/Account/UserClaim.cs
@@ -4,6 +4,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
@@ -32,6 +33,22 @@ namespace BrockAllen.MembershipReboot
         [StringLength(150)]
         [Required]
         public virtual string Value { get; protected internal set; }
+    }
+
+    public class UserClaimComparer : IComparer, IComparer<UserClaim>
+    {
+        public int Compare(object x, object y)
+        {
+            return Compare(x as UserClaim, y as UserClaim);
+        }
+
+        public int Compare(UserClaim x, UserClaim y)
+        {
+            int temp;
+            return (temp = string.Compare(x.Type, y.Type, StringComparison.Ordinal)) != 0 
+                ? temp 
+                : string.Compare(x.Value, y.Value, StringComparison.Ordinal);
+        }
     }
 
     public static class UserClaimCollectionExtensions


### PR DESCRIPTION
Fix "CreateAccount_CanPassCreatedDate_UsesCreatedDate" test - fails if run on machine with positive UTC offset - UserAccountService uses DateTime.UtcNow not DateTime.Now.

Fixes #532 