### PR TITLE
Updated GetCurentPrincipal in OwinAuthenticationService<TAccount>

### DIFF
--- a/src/BrockAllen.MembershipReboot.Owin/OwinAuthenticationService.cs
+++ b/src/BrockAllen.MembershipReboot.Owin/OwinAuthenticationService.cs
@@ -165,9 +165,14 @@ namespace BrockAllen.MembershipReboot.Owin
 
         protected override ClaimsPrincipal GetCurentPrincipal()
         {
-            var cp = context.Request.User as ClaimsPrincipal;
-            if (cp == null) cp = new ClaimsPrincipal(context.Request.User);
-            return cp;
+            var u = context.Request.User;
+            if (u != null && u.Identity.AuthenticationType == authenticationType)
+            {
+                var cp = context.Request.User as ClaimsPrincipal;
+                if (cp == null) cp = new ClaimsPrincipal(context.Request.User);
+                return cp;
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
As described in #543, this change brings the GetCurentPrincipal method in the generic OwinAuthenticationService in line with that defined in the [nongeneric version](https://github.com/brockallen/BrockAllen.MembershipReboot/blob/master/src/BrockAllen.MembershipReboot.Owin/OwinAuthenticationService.cs#L83-L93).