### PR TITLE
Allow unverified accounts to be authenticated for a limited amount of time.

### DIFF
--- a/NuGet/BrockAllen.MembershipReboot.da/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.da/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.da</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.de/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.de/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.de</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.nl/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.nl/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.nl</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.no/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.no/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.no</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.ru/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.ru/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.ru</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.sv/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.sv/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.sv</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.zh/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.zh/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.zh</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -1053,6 +1053,32 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
         }
 
         [TestMethod]
+        public void Authenticate_AccountNotVerified_VerificationWindowOpen_LoginAllowed()
+        {
+            this.configuration.RequireAccountVerification = true;
+            this.configuration.AllowUnverifiedAccountsWindow = TimeSpan.FromDays(1);
+            
+            subject.Now = new DateTime(2016, 2, 1, 11, 53, 0);
+            var acc = subject.CreateAccount("test", "pass", "test@test.com");
+            Assert.IsTrue(subject.Authenticate("test", "pass"));
+        }
+
+        [TestMethod]
+        public void Authenticate_AccountNotVerified_VerificationWindowOpen_Fails()
+        {
+            this.configuration.RequireAccountVerification = true;
+            this.configuration.AllowUnverifiedAccountsWindow = TimeSpan.FromDays(1);
+            var unvarifiedAccountAccessWindow = this.configuration.AllowUnverifiedAccountsWindow = TimeSpan.FromDays(1);
+
+            subject.Now = new DateTime(2016, 2, 1, 11, 53, 0);
+            var acc = subject.CreateAccount("test", "pass", "test@test.com");
+            subject.Now += unvarifiedAccountAccessWindow.Value.Add(TimeSpan.FromMilliseconds(1));
+            AuthenticationFailureCode failureCode;
+            Assert.IsFalse(subject.Authenticate("test", "pass", out failureCode));
+            Assert.AreEqual(AuthenticationFailureCode.AccountNotVerified, failureCode);
+        }
+
+        [TestMethod]
         public void Authenticate_LoginNotAllowed_Fails()
         {
             this.configuration.RequireAccountVerification = false;

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -988,7 +988,7 @@ namespace BrockAllen.MembershipReboot
                     }
 
                     if (Configuration.RequireAccountVerification &&
-                        !account.IsAccountVerified)
+                        (!account.IsAccountVerified && UnverifiedAccountAllowanceHasExpired(account)))
                     {
                         Tracing.Error("[UserAccountService.Authenticate] failed -- account not verified");
                         this.AddEvent(new AccountNotVerifiedEvent<TAccount>() { Account = account });
@@ -1056,6 +1056,16 @@ namespace BrockAllen.MembershipReboot
             Tracing.Verbose("[UserAccountService.Authenticate] authentication outcome: {0}", result ? "Successful Login" : "Failed Login");
 
             return result;
+        }
+
+        private bool UnverifiedAccountAllowanceHasExpired(TAccount account)
+        {
+            if (Configuration.AllowUnverifiedAccountsWindow.HasValue)
+            {
+                return account.Created.Add(Configuration.AllowUnverifiedAccountsWindow.Value) < UtcNow;
+            }
+
+            return true;
         }
 
         protected virtual bool Authenticate(TAccount account, string password)

--- a/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
@@ -31,7 +31,8 @@ namespace BrockAllen.MembershipReboot
             this.AllowAccountDeletion = securitySettings.AllowAccountDeletion;
             this.PasswordHashingIterationCount = securitySettings.PasswordHashingIterationCount;
             this.PasswordResetFrequency = securitySettings.PasswordResetFrequency;
-            this.VerificationKeyLifetime = securitySettings.VerificationKeyLifetime;
+            this.AllowUnverifiedAccountsWindow = securitySettings.AllowUnverifiedAccountsWindow;
+            this.VerificationKeyLifetime = securitySettings.AllowUnverifiedAccountsWindow ?? securitySettings.VerificationKeyLifetime;
 
             this.Crypto = new DefaultCrypto();
         }
@@ -49,6 +50,7 @@ namespace BrockAllen.MembershipReboot
         public int PasswordHashingIterationCount { get; set; }
         public int PasswordResetFrequency { get; set; }
         public TimeSpan VerificationKeyLifetime { get; set; }
+        public TimeSpan? AllowUnverifiedAccountsWindow { get; set; }
 
         internal void Validate()
         {

--- a/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
@@ -53,6 +53,7 @@ namespace BrockAllen.MembershipReboot
         private const string PASSWORDHASHINGITERATIONCOUNT = "passwordHashingIterationCount";
         private const string PASSWORDRESETFREQUENCY = "passwordResetFrequency";
         private const string VERIFICATIONKEYLIFETIME = "verificationKeyLifetime";
+        private const string ALLOWUNVERIFIEDACCOUNTSWINDOW = "allowUnverifiedAccountsWindow";
 
         [ConfigurationProperty(MULTITENANT, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.MultiTenant)]
         public bool MultiTenant
@@ -143,6 +144,13 @@ namespace BrockAllen.MembershipReboot
         {
             get { return (TimeSpan)this[VERIFICATIONKEYLIFETIME]; }
             set { this[VERIFICATIONKEYLIFETIME] = value; }
+        }
+
+        [ConfigurationProperty(ALLOWUNVERIFIEDACCOUNTSWINDOW)]
+        public TimeSpan? AllowUnverifiedAccountsWindow
+        {
+            get { return (TimeSpan?)this[ALLOWUNVERIFIEDACCOUNTSWINDOW]; }
+            set { this[ALLOWUNVERIFIEDACCOUNTSWINDOW] = value; }
         }
     }
 }


### PR DESCRIPTION
In the instance you want to require account verification but you want to allow new users to gain access to the website right away, without the need to wait for an activation email, this feature enables developers to open a temporary window of access. This feature is inspired by Slack's account onboarding procedure which gives new users a window of 3 days to activate their account. 

Note, however, that setting the new `AllowUnverifiedAccountsWindow` configuration setting will override the `VerificationKeyLifetime` setting to match. It doesn't seem to make sense that you'd have a verification key which expired before the verification window was closed but I would likely concede if that was deemed be too aggressive.

All tests are passing. I took the liberty of bumping the NuGet versions.