### PR TITLE
Put code at the start of the sms text

### DIFF
--- a/src/BrockAllen.MembershipReboot/Notification/SMS/SmsTemplates/Code.txt
+++ b/src/BrockAllen.MembershipReboot/Notification/SMS/SmsTemplates/Code.txt
@@ -1,1 +1,1 @@
-﻿Your {applicationName} verification code is {code}.
+﻿{code} is your {applicationName} verification code.


### PR DESCRIPTION
Both Google and Trello does this. It allows for peeking the text and swipe it away rather than clicking on it and viewing the text. Saves the user a click and a few secs.

Google's: "xxxxxx is your Google confirmation code."
Trello: "xxxxxx is your Trello verification code"