### PR TITLE
Add time based, Voice and Email options to the TwoFactorAuthMode enum…

### DIFF
--- a/src/BrockAllen.MembershipReboot/Account/TwoFactorAuthMode.cs
+++ b/src/BrockAllen.MembershipReboot/Account/TwoFactorAuthMode.cs
@@ -2,13 +2,15 @@
  * Copyright (c) Brock Allen.  All rights reserved.
  * see license.txt
  */
-
 namespace BrockAllen.MembershipReboot
 {
-    public enum TwoFactorAuthMode
-    {
-        None = 0,
-        Mobile = 1,
-        Certificate = 2
-    }
+  public enum TwoFactorAuthMode
+  {
+    None = 0,
+    Mobile = 1,
+    Certificate = 2,
+    TimeBasedToken = 3,
+    Voice = 4,
+    Email = 5
+  }
 }


### PR DESCRIPTION
….  This will allow us to use the extended values in our user service and controller in identity server, and in our event listeners that send codes via these methods.

We are extended Idsrv3 (and membership reboot) to perform 2fa via Voice call and email.  Later we would like to use TOTP (as in PR 594 - https://github.com/brockallen/BrockAllen.MembershipReboot/pull/594).

We hit a roadblock with this enum, since we need to pass current 2fa type around via the account, and we realized if we extend add the additional enum values, we can use them where we need to for our user service and event handlers.  Rather than maintain our own branch, we were hoping you could push this extended enum (or something similar) to allow these extensions?

Thanks for your consideration, - Eric
