### PR TITLE
Support for non-unique certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ pip-log.txt
 
 # SQL Lite DB files
 *.sqlite
+/NuGet/BrockAllen.MembershipReboot/lib/net45
+/NuGet/BrockAllen.MembershipReboot.Owin/lib/net45
+/NuGet/BrockAllen.MembershipReboot.sk/lib/net45/sk
+/NuGet/NuGet.exe

--- a/NuGet/BrockAllen.MembershipReboot.Owin/BrockAllen.MembershipReboot.Owin.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.Owin/BrockAllen.MembershipReboot.Owin.nuspec
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>BrockAllen.MembershipReboot.Owin</id>
+    <id>BrockAllen.MembershipReboot.Owin-sfera</id>
     <version>7.1.1</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
-    <projectUrl>https://github.com/brockallen/BrockAllen.MembershipReboot</projectUrl>
+    <projectUrl>https://github.com/mirecg/BrockAllen.MembershipReboot</projectUrl>
     <iconUrl>http://0.gravatar.com/avatar/f17c1816a6f9bff29a515c75b950460a?s=128&amp;d=mm&amp;r=G</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Claims-based user account and identity management framework</description>
@@ -15,7 +15,7 @@
     <tags>Membership Roles Claims Identity User Account Password Management Two Factor Authentication Certificate Authentication</tags>
     <language>en-US</language>
     <dependencies>
-      <dependency id="BrockAllen.MembershipReboot" version="8.4.0" />
+      <dependency id="BrockAllen.MembershipReboot-sfera" version="8.4.1" />
       <dependency id="Microsoft.Owin.Security.Cookies" version="2.1" />
     </dependencies>
   </metadata>

--- a/NuGet/BrockAllen.MembershipReboot.sk.cmd
+++ b/NuGet/BrockAllen.MembershipReboot.sk.cmd
@@ -1,0 +1,3 @@
+mkdir BrockAllen.MembershipReboot.sk\lib\net45\sk
+xcopy ..\build\sk\BrockAllen.MembershipReboot.resources.dll BrockAllen.MembershipReboot.sk\lib\net45\sk /y
+NuGet.exe pack BrockAllen.MembershipReboot.sk\BrockAllen.MembershipReboot.nuspec -OutputDirectory .

--- a/NuGet/BrockAllen.MembershipReboot.sk/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.sk/BrockAllen.MembershipReboot.nuspec
@@ -1,27 +1,22 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>BrockAllen.MembershipReboot.WebHost-sfera</id>
-    <version>7.1.0</version>
-    <authors>BrockAllen</authors>
+    <id>BrockAllen.MembershipReboot-sfera.sk</id>
+    <version>8.4.1</version>
+    <authors>BrockAllen,sfera</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
-    <projectUrl>https://github.com/brockallen/BrockAllen.MembershipReboot</projectUrl>
+    <projectUrl>https://github.com/mirecg/BrockAllen.MembershipReboot</projectUrl>
     <iconUrl>http://0.gravatar.com/avatar/f17c1816a6f9bff29a515c75b950460a?s=128&amp;d=mm&amp;r=G</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Claims-based user account and identity management framework</description>
     <releaseNotes></releaseNotes>
-    <copyright>Copyright 2014</copyright>
+    <copyright>Copyright 2015, Copyright 2016 - sféra,a.s.</copyright>
     <tags>Membership Roles Claims Identity User Account Password Management Two Factor Authentication Certificate Authentication</tags>
-    <language>en-US</language>
-
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.IdentityModel" targetFramework="net45" />
-      <frameworkAssembly assemblyName="System.IdentityModel.Services" targetFramework="net45" />
-    </frameworkAssemblies>
+    <language>sk</language>
 
     <dependencies>
-      <dependency id="BrockAllen.MembershipReboot-sfera" version="8.4.1" />
+		<dependency id="BrockAllen.MembershipReboot-sfera" version="[8.4.1]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.nuspec
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>BrockAllen.MembershipReboot</id>
-    <version>8.4.0</version>
-    <authors>BrockAllen</authors>
+    <id>BrockAllen.MembershipReboot-sfera</id>
+    <version>8.4.1</version>
+    <authors>BrockAllen,sfera</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
-    <projectUrl>https://github.com/brockallen/BrockAllen.MembershipReboot</projectUrl>
+    <projectUrl>https://github.com/mirecg/BrockAllen.MembershipReboot</projectUrl>
     <iconUrl>http://0.gravatar.com/avatar/f17c1816a6f9bff29a515c75b950460a?s=128&amp;d=mm&amp;r=G</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Claims-based user account and identity management framework</description>
     <releaseNotes></releaseNotes>
-    <copyright>Copyright 2015</copyright>
+    <copyright>Copyright 2015, Copyright 2016 - sféra,a.s.</copyright>
     <tags>Membership Roles Claims Identity User Account Password Management Two Factor Authentication Certificate Authentication</tags>
     <language>en-US</language>
 

--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -2763,5 +2763,22 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
             }
         }
 
+        [TestMethod]
+        public void CreateAccount_RequirePasswordResetAfterAccountCreation_Sets_RequiresPasswordReset_True()
+        {
+            configuration.RequirePasswordResetAfterAccountCreation = true;
+
+            var acct1 = subject.CreateAccount("test1", "pass", "test1@test.com");
+            Assert.IsTrue(acct1.RequiresPasswordReset, "RequirePasswordResetAfterAccountCreation = true should set Account.RequiresPasswordReset = true after account creation");
+        }
+
+        [TestMethod]
+        public void CreateAccount_Not_RequirePasswordResetAfterAccountCreation_Sets_RequiresPasswordReset_False()
+        {
+            configuration.RequirePasswordResetAfterAccountCreation = false;
+
+            var acct1 = subject.CreateAccount("test1", "pass", "test1@test.com");
+            Assert.IsFalse(acct1.RequiresPasswordReset, "RequirePasswordResetAfterAccountCreation = false should set Account.RequiresPasswordReset = false after account creation");
+        }
     }
 }

--- a/src/BrockAllen.MembershipReboot.Test/Configuration/SecuritySettingsTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/Configuration/SecuritySettingsTests.cs
@@ -28,6 +28,7 @@ namespace BrockAllen.MembershipReboot.Test.Accounts
             Assert.AreEqual(0, settings.PasswordHashingIterationCount);
             Assert.AreEqual(0, settings.PasswordResetFrequency);
             Assert.AreEqual(TimeSpan.FromMinutes(20), settings.VerificationKeyLifetime);
+            Assert.AreEqual(true, settings.CertificateIsUnique);
         }
     }
 }

--- a/src/BrockAllen.MembershipReboot.Test/Configuration/SecuritySettingsTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/Configuration/SecuritySettingsTests.cs
@@ -30,6 +30,7 @@ namespace BrockAllen.MembershipReboot.Test.Accounts
             Assert.AreEqual(TimeSpan.FromMinutes(20), settings.VerificationKeyLifetime);
             Assert.AreEqual(true, settings.CertificateIsUnique);
             Assert.AreEqual(true, settings.MobilePhoneIsUnique);
+            Assert.AreEqual(false, settings.RequirePasswordResetAfterAccountCreation);
         }
     }
 }

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -1302,7 +1302,8 @@ namespace BrockAllen.MembershipReboot
 
             Tracing.Verbose("[UserAccountService.Authenticate] cert: {0}", certificate.Thumbprint);
 
-            if (!(certificate.NotBefore < UtcNow && UtcNow < certificate.NotAfter))
+            var localNow = DateTime.Now;
+            if (!(certificate.NotBefore < localNow && localNow < certificate.NotAfter))
             {
                 Tracing.Error("[UserAccountService.Authenticate] failed -- invalid certificate dates");
                 this.AddEvent(new InvalidCertificateEvent<TAccount> { Account = account, Certificate = certificate });

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -1512,7 +1512,8 @@ namespace BrockAllen.MembershipReboot
 
             ValidatePassword(account, newPassword);
 
-            if (!account.IsAccountVerified)
+            // IsAccountVerified checks should be consistent with Configuration.RequireAccountVerification
+            if (Configuration.RequireAccountVerification && !account.IsAccountVerified)
             {
                 Tracing.Error("[UserAccountService.ChangePasswordFromResetKey] failed -- account not verified");
                 return false;
@@ -1711,7 +1712,8 @@ namespace BrockAllen.MembershipReboot
             var account = this.GetByEmail(tenant, email);
             if (account == null) throw new ValidationException(GetValidationMessage(MembershipRebootConstants.ValidationMessages.InvalidEmail));
 
-            if (!account.IsAccountVerified)
+            // IsAccountVerified checks should be consistent with Configuration.RequireAccountVerification
+            if (Configuration.RequireAccountVerification && !account.IsAccountVerified)
             {
                 Tracing.Error("[UserAccountService.SendUsernameReminder] failed -- account not verified");
                 throw new ValidationException(GetValidationMessage(MembershipRebootConstants.ValidationMessages.AccountNotVerified));
@@ -2219,7 +2221,8 @@ namespace BrockAllen.MembershipReboot
                 throw new ValidationException(GetValidationMessage(MembershipRebootConstants.ValidationMessages.PasswordResetErrorNoEmail));
             }
 
-            if (!account.IsAccountVerified)
+            // IsAccountVerified checks should be consistent with Configuration.RequireAccountVerification
+            if (Configuration.RequireAccountVerification && !account.IsAccountVerified)
             {
                 // if they've not yet verified then don't allow password reset
                 if (account.IsNew())

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountValidator.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountValidator.cs
@@ -25,12 +25,15 @@ namespace BrockAllen.MembershipReboot
             if (evt.Account == null) throw new ArgumentNullException("account");
             if (evt.Certificate == null) throw new ArgumentNullException("certificate");
 
-            var account = evt.Account;
-            var otherAccount = userAccountService.GetByCertificate(account.Tenant, evt.Certificate.Thumbprint);
-            if (otherAccount != null && otherAccount.ID != account.ID)
+            if (userAccountService.Configuration.CertificateIsUnique)
             {
-                Tracing.Verbose("[UserAccountValidation.CertificateThumbprintMustBeUnique] validation failed: {0}, {1}", account.Tenant, account.Username);
-                throw new ValidationException(userAccountService.GetValidationMessage("CertificateAlreadyInUse"));
+                var account = evt.Account;
+                var otherAccount = userAccountService.GetByCertificate(account.Tenant, evt.Certificate.Thumbprint);
+                if (otherAccount != null && otherAccount.ID != account.ID)
+                {
+                    Tracing.Verbose("[UserAccountValidation.CertificateThumbprintMustBeUnique] validation failed: {0}, {1}", account.Tenant, account.Username);
+                    throw new ValidationException(userAccountService.GetValidationMessage("CertificateAlreadyInUse"));
+                }
             }
         }
     }

--- a/src/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.csproj
+++ b/src/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.csproj
@@ -183,6 +183,7 @@
       <LastGenOutput>ValidationMessages.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\ValidationMessages.sk.resx" />
     <EmbeddedResource Include="Resources\ValidationMessages.sv.resx" />
     <EmbeddedResource Include="Resources\ValidationMessages.zh-cn.resx" />
   </ItemGroup>

--- a/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
@@ -32,6 +32,7 @@ namespace BrockAllen.MembershipReboot
             this.PasswordHashingIterationCount = securitySettings.PasswordHashingIterationCount;
             this.PasswordResetFrequency = securitySettings.PasswordResetFrequency;
             this.VerificationKeyLifetime = securitySettings.VerificationKeyLifetime;
+            this.CertificateIsUnique = securitySettings.CertificateIsUnique;
 
             this.Crypto = new DefaultCrypto();
         }
@@ -49,6 +50,7 @@ namespace BrockAllen.MembershipReboot
         public int PasswordHashingIterationCount { get; set; }
         public int PasswordResetFrequency { get; set; }
         public TimeSpan VerificationKeyLifetime { get; set; }
+        public bool CertificateIsUnique { get; set; }
 
         internal void Validate()
         {

--- a/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
@@ -34,6 +34,7 @@ namespace BrockAllen.MembershipReboot
             this.VerificationKeyLifetime = securitySettings.VerificationKeyLifetime;
             this.CertificateIsUnique = securitySettings.CertificateIsUnique;
             this.MobilePhoneIsUnique = securitySettings.MobilePhoneIsUnique;
+            this.RequirePasswordResetAfterAccountCreation = securitySettings.RequirePasswordResetAfterAccountCreation;
 
             this.Crypto = new DefaultCrypto();
         }
@@ -53,6 +54,7 @@ namespace BrockAllen.MembershipReboot
         public TimeSpan VerificationKeyLifetime { get; set; }
         public bool CertificateIsUnique { get; set; }
         public bool MobilePhoneIsUnique { get; set; }
+        public bool RequirePasswordResetAfterAccountCreation { get; set; }
 
 
         internal void Validate()

--- a/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
@@ -53,6 +53,7 @@ namespace BrockAllen.MembershipReboot
         private const string PASSWORDHASHINGITERATIONCOUNT = "passwordHashingIterationCount";
         private const string PASSWORDRESETFREQUENCY = "passwordResetFrequency";
         private const string VERIFICATIONKEYLIFETIME = "verificationKeyLifetime";
+        private const string CERTIFICATEISUNIQUE = "certificateIsUnique";
 
         [ConfigurationProperty(MULTITENANT, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.MultiTenant)]
         public bool MultiTenant
@@ -144,5 +145,13 @@ namespace BrockAllen.MembershipReboot
             get { return (TimeSpan)this[VERIFICATIONKEYLIFETIME]; }
             set { this[VERIFICATIONKEYLIFETIME] = value; }
         }
+
+        [ConfigurationProperty(CERTIFICATEISUNIQUE, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.CertificateIsUnique)]
+        public bool CertificateIsUnique
+        {
+            get { return (bool) this[CERTIFICATEISUNIQUE]; }
+            set { this[CERTIFICATEISUNIQUE] = value; }
+        }
+
     }
 }

--- a/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
@@ -55,6 +55,7 @@ namespace BrockAllen.MembershipReboot
         private const string VERIFICATIONKEYLIFETIME = "verificationKeyLifetime";
         private const string CERTIFICATEISUNIQUE = "certificateIsUnique";
         private const string MOBILEPHONEISUNIQUE = "mobilePhoneIsUnique";
+        private const string REQUIREPASSWORDRESETAFTERACCOUNTCREATION = "requirePasswordResetAfterAccountCreation";
 
         [ConfigurationProperty(MULTITENANT, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.MultiTenant)]
         public bool MultiTenant
@@ -159,6 +160,13 @@ namespace BrockAllen.MembershipReboot
         {
             get { return (bool) this[MOBILEPHONEISUNIQUE]; }
             set { this[MOBILEPHONEISUNIQUE] = value; }
+        }
+
+        [ConfigurationProperty(REQUIREPASSWORDRESETAFTERACCOUNTCREATION, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.RequirePasswordResetAfterAccountCreation)]
+        public bool RequirePasswordResetAfterAccountCreation
+        {
+            get { return (bool) this[REQUIREPASSWORDRESETAFTERACCOUNTCREATION]; }
+            set { this[REQUIREPASSWORDRESETAFTERACCOUNTCREATION] = value; }
         }
     }
 }

--- a/src/BrockAllen.MembershipReboot/Constants/MembershipRebootConstants.cs
+++ b/src/BrockAllen.MembershipReboot/Constants/MembershipRebootConstants.cs
@@ -32,6 +32,7 @@ namespace BrockAllen.MembershipReboot
             internal const string VerificationKeyLifetime = "00:20:00";
             internal const bool CertificateIsUnique = true;
             internal const bool MobilePhoneIsUnique = true;
+            internal const bool RequirePasswordResetAfterAccountCreation = false;
         }
 
         public class UserAccount

--- a/src/BrockAllen.MembershipReboot/Constants/MembershipRebootConstants.cs
+++ b/src/BrockAllen.MembershipReboot/Constants/MembershipRebootConstants.cs
@@ -30,6 +30,7 @@ namespace BrockAllen.MembershipReboot
             internal const int PasswordHashingIterationCount = 0;
             internal const int PasswordResetFrequency = 0;
             internal const string VerificationKeyLifetime = "00:20:00";
+            internal const bool CertificateIsUnique = true;
         }
 
         public class UserAccount

--- a/src/BrockAllen.MembershipReboot/Properties/AssemblyInfo.cs
+++ b/src/BrockAllen.MembershipReboot/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("BrockAllen.MembershipReboot")]
+[assembly: AssemblyTitle("BrockAllen.MembershipReboot - sfera")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Brock Allen Consulting, LLC")]
@@ -35,4 +35,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("8.4.0.0")]
-[assembly: AssemblyFileVersion("8.4.0.0")]
+[assembly: AssemblyFileVersion("8.4.1.1")]

--- a/src/BrockAllen.MembershipReboot/Resources/ValidationMessages.sk.resx
+++ b/src/BrockAllen.MembershipReboot/Resources/ValidationMessages.sk.resx
@@ -1,0 +1,279 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AccountAlreadyVerified" xml:space="preserve">
+    <value>E-mailová adresa pre tento účet je už overená.</value>
+  </data>
+  <data name="AccountCreateFailNoEmailFromIdp" xml:space="preserve">
+    <value>Nemožno vytvoriť účet, pretože tam nebol žiadny e-mail od poskytovateľa identity.</value>
+  </data>
+  <data name="AccountNotConfiguredWithSecretQuestion" xml:space="preserve">
+    <value>Tento účet nie je nakonfigurovaný s tajnou otázkou alebo odpoveďou.</value>
+  </data>
+  <data name="AccountNotVerified" xml:space="preserve">
+    <value>E-mailová adresa pre tento účet ešte nie je overená.</value>
+  </data>
+  <data name="AccountPasswordResetRequiresSecretQuestion" xml:space="preserve">
+    <value>Tento účet vyžaduje tajnú otázku a odpoveď na reset hesla.</value>
+  </data>
+  <data name="AddClientCertForTwoFactor" xml:space="preserve">
+    <value>Pridajte klientsky certifikát pre potreby overenia druhým faktorom.</value>
+  </data>
+  <data name="CantRemoveLastLinkedAccountIfNoPassword" xml:space="preserve">
+    <value>Pred odobratím posledného externého poskytovateľa prihlásenia je nutné nastaviť heslo pre lokálne konto.</value>
+  </data>
+  <data name="CertificateAlreadyInUse" xml:space="preserve">
+    <value>Tento certifikát už používa iný účet.</value>
+  </data>
+  <data name="CodeRequired" xml:space="preserve">
+    <value>Kód je povinný.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>Email sa už používa.</value>
+  </data>
+  <data name="EmailRequired" xml:space="preserve">
+    <value>Email je povinný.</value>
+  </data>
+  <data name="InvalidCertificate" xml:space="preserve">
+    <value>Neplatný certifikát.</value>
+  </data>
+  <data name="InvalidEmail" xml:space="preserve">
+    <value>Neplatný email.</value>
+  </data>
+  <data name="InvalidKey" xml:space="preserve">
+    <value>Neplatný kľúč.</value>
+  </data>
+  <data name="InvalidName" xml:space="preserve">
+    <value>Neplatné meno.</value>
+  </data>
+  <data name="InvalidNewPassword" xml:space="preserve">
+    <value>Neplatné nové heslo.</value>
+  </data>
+  <data name="InvalidOldPassword" xml:space="preserve">
+    <value>Neplatné staré heslo.</value>
+  </data>
+  <data name="InvalidPassword" xml:space="preserve">
+    <value>Neplatné heslo.</value>
+  </data>
+  <data name="InvalidPhone" xml:space="preserve">
+    <value>Neplatné telefónne číslo.</value>
+  </data>
+  <data name="InvalidQuestionOrAnswer" xml:space="preserve">
+    <value>Neplatná tajná otázka alebo odpoveď.</value>
+  </data>
+  <data name="InvalidTenant" xml:space="preserve">
+    <value>Neplatný tenant.</value>
+  </data>
+  <data name="InvalidUsername" xml:space="preserve">
+    <value>Neplatné prihlasovacie meno.</value>
+  </data>
+  <data name="LinkedAccountAlreadyInUse" xml:space="preserve">
+    <value>Externý účet je už spojený s iným užívateľom.</value>
+  </data>
+  <data name="LoginFailEmailAlreadyAssociated" xml:space="preserve">
+    <value>Nedá sa prihlásiť pomocou tohto poskytovateľa, pretože email je už prepojený s iným účtom. Prosím, prihláste sa pomocou svojho lokálneho účtu a potom priraďte poskytovateľa.</value>
+  </data>
+  <data name="LoginNotAllowed" xml:space="preserve">
+    <value>Prihlásenie nie je povolené pre tento účet.</value>
+  </data>
+  <data name="MobilePhoneAlreadyInUse" xml:space="preserve">
+    <value>Toto telefónne číslo je už použité iným účtom.</value>
+  </data>
+  <data name="MobilePhoneMustBeDifferent" xml:space="preserve">
+    <value>Telefónne číslo musí byť iné ako je aktuálne.</value>
+  </data>
+  <data name="MobilePhoneRequired" xml:space="preserve">
+    <value>Telefónne číslo je povinné.</value>
+  </data>
+  <data name="NameAlreadyInUse" xml:space="preserve">
+    <value>Toto meno je už použité.</value>
+  </data>
+  <data name="NameRequired" xml:space="preserve">
+    <value>Meno je povinné.</value>
+  </data>
+  <data name="NewPasswordMustBeDifferent" xml:space="preserve">
+    <value>Nové heslo musí byť odlišné od starého hesla.</value>
+  </data>
+  <data name="PasswordComplexityRules" xml:space="preserve">
+    <value>Heslo musí obsahovať aspoň {0} z nasledovných znakov: jeden malý, jeden veľký, jedno číslo a jeden ďalší.</value>
+  </data>
+  <data name="PasswordLength" xml:space="preserve">
+    <value>Heslo musí byť aspoň {0} znakov dlhé.</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Heslo je povinné.</value>
+  </data>
+  <data name="PasswordResetErrorNoEmail" xml:space="preserve">
+    <value>Resetovanie hesla nie je možné, lebo e-mailová adresa nebola overená pre tento účet.</value>
+  </data>
+  <data name="RegisterMobileForTwoFactor" xml:space="preserve">
+    <value>Zaregistrujte číslo mobilného telefónu, pre možnosť dvojfaktorového overenie cez SMS.</value>
+  </data>
+  <data name="ReopenErrorNoEmail" xml:space="preserve">
+    <value>Znovuotvorenie účtu nie je možné, pretože neexistuje žiadna e-mailová adresa pre tento účet.</value>
+  </data>
+  <data name="SecretAnswerRequired" xml:space="preserve">
+    <value>Tajná odpoveď je povinná.</value>
+  </data>
+  <data name="SecretQuestionAlreadyInUse" xml:space="preserve">
+    <value>Táto tajná otázka pre resetovanie hesla je už použitá.</value>
+  </data>
+  <data name="SecretQuestionRequired" xml:space="preserve">
+    <value>Tajná otázka je povinná.</value>
+  </data>
+  <data name="TenantRequired" xml:space="preserve">
+    <value>Tenant je povinný.</value>
+  </data>
+  <data name="UsernameAlreadyInUse" xml:space="preserve">
+    <value>Prihlasovacie meno je už použité.</value>
+  </data>
+  <data name="UsernameCannotContainAtSign" xml:space="preserve">
+    <value>Prihlasovacie meno nemôže obsahovať znak '@'.</value>
+  </data>
+  <data name="UsernameCanOnlyStartOrEndWithLetterOrDigit" xml:space="preserve">
+    <value>Prihlasovacie meno môže začínať alebo končiť iba písmenom alebo číslom.</value>
+  </data>
+  <data name="UsernameOnlyContainsValidCharacters" xml:space="preserve">
+    <value>Užívateľské meno môže obsahovať len písmená, číslice, medzery, bodky, pomlčky alebo podčiarkovník.</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>Prihlasovacie meno je povinné.</value>
+  </data>
+  <data name="UsernameCannotRepeatSpecialCharacters" xml:space="preserve">
+    <value>Užívateľské meno nemôže mať dve medzery, bodky, pomlčky alebo podčiarkovaníky vedľa seba.</value>
+  </data>
+  <data name="AccountClosed" xml:space="preserve">
+    <value>Účet je zatvorený.</value>
+  </data>
+  <data name="AccountNotConfiguredWithCertificates" xml:space="preserve">
+    <value>Pre prihlásenie tento účet musí byť nakonfigurovaný s certifikátmi.</value>
+  </data>
+  <data name="AccountNotConfiguredWithMobilePhone" xml:space="preserve">
+    <value>Pre prihlásenie tento účet musí byť nakonfigurovaný s číslom mobilného telefónu.</value>
+  </data>
+  <data name="FailedLoginAttemptsExceeded" xml:space="preserve">
+    <value>Bol prekročený počet povolených pokusov o prihlásenie.</value>
+  </data>
+  <data name="InvalidCredentials" xml:space="preserve">
+    <value>Neplatné meno alebo heslo.</value>
+  </data>
+  <data name="UsernameOnlyContainLettersAndDigits" xml:space="preserve">
+    <value>Prihlasovacie meno môže obsahovať len písmena a číslice.</value>
+  </data>
+</root>


### PR DESCRIPTION
Support for allowing non-unique certificates in user accounts through configuration property CertificateIsUnique, which is true by default (this is original behavior) as discussed in #645.
